### PR TITLE
Remove H1 from the heading in LPTHW_ex22_definitions_sheet.md

### DIFF
--- a/LPTHW_ex22_definitions_sheet.md
+++ b/LPTHW_ex22_definitions_sheet.md
@@ -1,4 +1,4 @@
-# H1 What do you know so far?
+# What do you know so far?
 
 | Term, method,character      | Definition          | Example |
 | ------------- |:-------------:| -----:|


### PR DESCRIPTION
Everything looks good, I just thought that removing _H1_ from the heading would make it cleaner since one # means h1. Let m know what you think.